### PR TITLE
Audio: use ADC right channel for microphone.

### DIFF
--- a/firmware/baseband/audio_input.cpp
+++ b/firmware/baseband/audio_input.cpp
@@ -36,5 +36,5 @@ void AudioInput::read_audio_buffer(buffer_s16_t& audio) {
 	auto audio_buffer = audio::dma::rx_empty_buffer();
 	
 	for (size_t i=0; i<audio_buffer.count; i++)
-		audio.p[i] = audio_buffer.p[i].left;
+		audio.p[i] = audio_buffer.p[i].right;
 }


### PR DESCRIPTION
AK4951 produces mic data only in right channel. WM8731 places mic samples on both channels.
Addresses issue #76.