### PR TITLE
Unable to build due to a missing LGE app declaration in CMakeLists

### DIFF
--- a/firmware/application/CMakeLists.txt
+++ b/firmware/application/CMakeLists.txt
@@ -250,6 +250,7 @@ set(CPPSRC
 	apps/analog_audio_app.cpp
 	apps/capture_app.cpp
 	apps/ert_app.cpp
+	apps/lge_app.cpp
 	apps/pocsag_app.cpp
 	apps/replay_app.cpp
 	apps/soundboard_app.cpp


### PR DESCRIPTION
[100%] Linking CXX executable application.elf
CMakeFiles/application.elf.dir/ui_navigation.cpp.obj: In function `std::_Function_handler<void (), ui::TransmittersMenuView::TransmittersMenuView(ui::NavigationView&)::{lambda()#6}>::_M_invoke(std::_Any_data const&)':
/tmp/portapack-havoc/firmware/application/ui_navigation.hpp:71: undefined reference to `ui::LGEView::LGEView(ui::NavigationView&)'
collect2: error: ld returned 1 exit status
make[3]: *** [firmware/application/application.elf] Error 1
make[2]: *** [firmware/application/CMakeFiles/application.elf.dir/all] Error 2
make[1]: *** [firmware/CMakeFiles/firmware.dir/rule] Error 2
make: *** [firmware] Error 2


Thx for this great firmware ;)