### PR TITLE
Fixed AIS RX  negative Lat/Long

### DIFF
--- a/firmware/application/apps/ais_app.cpp
+++ b/firmware/application/apps/ais_app.cpp
@@ -53,8 +53,7 @@ static std::string latlon(const Latitude latitude, const Longitude longitude) {
 }
 
 static float latlon_float(const int32_t normalized) {
-	const uint32_t normalized_abs = std::abs(normalized);
-	return ((((float) normalized_abs) * 5) / 3) / (100 * 10000);
+	return ((((float) normalized) * 5) / 3) / (100 * 10000);
 }
 
 static std::string mmsi(


### PR DESCRIPTION
On AIS RX the float convert function for lat lon always returns the abs of the lat or lon.  The string functions correctly show a suffix of NS or EW.

Example, lon label for -77 was correct as 77W.  But when converting to float for display on the map the lon would be the abs of lon.  This fix now show AIS locations correctly for negative lat and lon.
