### PR TITLE
ADSB RX: fix negative lat/lon formatting and insure two decimal places

### DIFF
--- a/firmware/application/apps/ui_adsb_rx.cpp
+++ b/firmware/application/apps/ui_adsb_rx.cpp
@@ -226,9 +226,9 @@ void ADSBRxView::on_frame(const ADSBFrameMessage * message) {
 				if (entry.pos.valid) {
 					str_info = "Alt:" + to_string_dec_uint(entry.pos.altitude) +
 						" Lat" + to_string_dec_int(entry.pos.latitude) +
-						"." + to_string_dec_int((int)(entry.pos.latitude * 1000) % 100) +
+						"." + to_string_dec_int((int)abs(entry.pos.latitude * 1000) % 100, 2, '0') +
 						" Lon" + to_string_dec_int(entry.pos.longitude) +
-						"." + to_string_dec_int((int)(entry.pos.longitude * 1000) % 100);
+						"." + to_string_dec_int((int)abs(entry.pos.longitude * 1000) % 100, 2, '0');
 					
 					entry.set_info_string(str_info);
 					logentry+=str_info+ " ";


### PR DESCRIPTION
Here's an example from adsb.txt that shows the issue:

    20191221095823 8DA39F0D580F3122241664A6B9D8 ICAO:A39F0D Alt:1875 Lat37.0 Lon-122.-18 ^M
