### PR TITLE
Category label and entry to 12 chars

### DIFF
--- a/firmware/application/apps/ui_freqman.cpp
+++ b/firmware/application/apps/ui_freqman.cpp
@@ -259,7 +259,7 @@ void FrequencyManagerView::on_edit_desc(NavigationView& nav) {
 }
 
 void FrequencyManagerView::on_new_category(NavigationView& nav) {
-	text_prompt(nav, desc_buffer, 8, [this](std::string& buffer) {
+	text_prompt(nav, desc_buffer, 12, [this](std::string& buffer) {
 		File freqman_file;
 		create_freqman_file(buffer, freqman_file);
 	});

--- a/firmware/application/apps/ui_freqman.hpp
+++ b/firmware/application/apps/ui_freqman.hpp
@@ -64,7 +64,7 @@ protected:
 	
 	OptionsField options_category {
 		{ 9 * 8, 4 },
-		8,
+		12,
 		{ }
 	};
 	


### PR DESCRIPTION
The categories names in the frequency manager are limited to 8 chars, however in the supplied SD there are longer names that produce drawing issues:
![image](https://user-images.githubusercontent.com/1091420/78563039-a1f6a480-781a-11ea-8566-75c8275e1dac.png)

Increasing the label limit to 12 solves everything and allows more descriptive names.