### PR TITLE
Few improvements in ui_transmitter

### DIFF
--- a/firmware/application/apps/lge_app.cpp
+++ b/firmware/application/apps/lge_app.cpp
@@ -240,7 +240,6 @@ void LGEView::start_tx() {
 		tx_view.set_dirty();
 	}
 	transmitter_model.set_sampling_rate(2280000);
-	transmitter_model.set_rf_amp(true);
 	transmitter_model.set_baseband_bandwidth(1750000);
 	transmitter_model.enable();
 

--- a/firmware/application/apps/ui_adsb_tx.cpp
+++ b/firmware/application/apps/ui_adsb_tx.cpp
@@ -310,7 +310,6 @@ void ADSBTxView::start_tx() {
 	generate_frames();
 	
 	transmitter_model.set_sampling_rate(4000000U);
-	transmitter_model.set_rf_amp(true);
 	transmitter_model.set_baseband_bandwidth(10000000);
 	transmitter_model.enable();
 	

--- a/firmware/application/apps/ui_aprs_tx.cpp
+++ b/firmware/application/apps/ui_aprs_tx.cpp
@@ -58,7 +58,6 @@ void APRSTXView::start_tx() {
 	
 	transmitter_model.set_tuning_frequency(persistent_memory::tuned_frequency());
 	transmitter_model.set_sampling_rate(AFSK_TX_SAMPLERATE);
-	transmitter_model.set_rf_amp(true);
 	transmitter_model.set_baseband_bandwidth(1750000);
 	transmitter_model.enable();
 	
@@ -108,7 +107,10 @@ APRSTXView::APRSTXView(NavigationView& nav) {
 	};
 	
 	tx_view.on_edit_frequency = [this, &nav]() {
-		return;
+		auto new_view = nav.push<FrequencyKeypadView>(receiver_model.tuning_frequency());
+		new_view->on_changed = [this](rf::Frequency f) {
+			receiver_model.set_tuning_frequency(f);
+		};
 	};
 	
 	tx_view.on_start = [this]() {

--- a/firmware/application/apps/ui_bht_tx.cpp
+++ b/firmware/application/apps/ui_bht_tx.cpp
@@ -37,7 +37,6 @@ void BHTView::focus() {
 void BHTView::start_tx() {
 	baseband::shutdown();
 	
-	transmitter_model.set_rf_amp(true);
 	transmitter_model.set_baseband_bandwidth(1750000);
 	
 	if (target_system == XYLOS) {

--- a/firmware/application/apps/ui_coasterp.cpp
+++ b/firmware/application/apps/ui_coasterp.cpp
@@ -68,7 +68,6 @@ void CoasterPagerView::start_tx() {
 	generate_frame();
 	
 	transmitter_model.set_sampling_rate(2280000);
-	transmitter_model.set_rf_amp(true);
 	transmitter_model.set_baseband_bandwidth(1750000);
 	transmitter_model.enable();
 

--- a/firmware/application/apps/ui_keyfob.cpp
+++ b/firmware/application/apps/ui_keyfob.cpp
@@ -186,7 +186,6 @@ void KeyfobView::start_tx() {
 	size_t bitstream_length = generate_frame();
 
 	transmitter_model.set_sampling_rate(OOK_SAMPLERATE);
-	transmitter_model.set_rf_amp(true);
 	transmitter_model.set_baseband_bandwidth(1750000);
 	transmitter_model.enable();
 	

--- a/firmware/application/apps/ui_lcr.cpp
+++ b/firmware/application/apps/ui_lcr.cpp
@@ -130,7 +130,6 @@ void LCRView::start_tx(const bool scan) {
 
 	transmitter_model.set_tuning_frequency(persistent_memory::tuned_frequency());
 	transmitter_model.set_sampling_rate(AFSK_TX_SAMPLERATE);
-	transmitter_model.set_rf_amp(true);
 	transmitter_model.set_baseband_bandwidth(1750000);
 	transmitter_model.enable();
 

--- a/firmware/application/apps/ui_mictx.cpp
+++ b/firmware/application/apps/ui_mictx.cpp
@@ -63,7 +63,6 @@ void MicTXView::set_tx(bool enable) {
 	if (enable) {
 		transmitting = true;
 		configure_baseband();
-		transmitter_model.set_rf_amp(true);
 		transmitter_model.enable();
 		portapack::pin_i2s0_rx_sda.mode(3);		// This is already done in audio::init but gets changed by the CPLD overlay reprogramming
 		//gpio_tx.write(1);
@@ -75,7 +74,6 @@ void MicTXView::set_tx(bool enable) {
 		} else {
 			transmitting = false;
 			configure_baseband();
-			transmitter_model.set_rf_amp(false);
 			transmitter_model.disable();
 			//gpio_tx.write(0);
 			//led_tx.off();
@@ -207,7 +205,6 @@ MicTXView::MicTXView(
 	field_va_decay.set_value(1000);
 	
 	transmitter_model.set_sampling_rate(sampling_rate);
-	transmitter_model.set_rf_amp(false);
 	transmitter_model.set_baseband_bandwidth(1750000);
 	
 	set_tx(false);

--- a/firmware/application/apps/ui_morse.cpp
+++ b/firmware/application/apps/ui_morse.cpp
@@ -100,7 +100,6 @@ bool MorseView::start_tx() {
 	progressbar.set_max(symbol_count);
 	
 	transmitter_model.set_sampling_rate(1536000U);
-	transmitter_model.set_rf_amp(true);
 	transmitter_model.set_baseband_bandwidth(1750000);
 	transmitter_model.enable();
 	

--- a/firmware/application/apps/ui_pocsag_tx.cpp
+++ b/firmware/application/apps/ui_pocsag_tx.cpp
@@ -79,9 +79,6 @@ bool POCSAGTXView::start_tx() {
 	progressbar.set_max(total_frames);
 	
 	transmitter_model.set_sampling_rate(2280000);
-	transmitter_model.set_rf_amp(true);
-	transmitter_model.set_lna(40);
-	transmitter_model.set_vga(40);
 	transmitter_model.set_baseband_bandwidth(1750000);
 	transmitter_model.enable();
 	

--- a/firmware/application/apps/ui_rds.cpp
+++ b/firmware/application/apps/ui_rds.cpp
@@ -204,7 +204,6 @@ void RDSView::start_tx() {
 		frame_datetime.clear();
 	
 	transmitter_model.set_sampling_rate(2280000U);
-	transmitter_model.set_rf_amp(true);
 	transmitter_model.set_baseband_bandwidth(1750000);
 	transmitter_model.enable();
 	

--- a/firmware/application/apps/ui_sstvtx.cpp
+++ b/firmware/application/apps/ui_sstvtx.cpp
@@ -166,7 +166,6 @@ void SSTVTXView::start_tx() {
 	prepare_scanline();		// Preload one scanline
 	
 	transmitter_model.set_sampling_rate(3072000U);
-	transmitter_model.set_rf_amp(true);
 	transmitter_model.set_baseband_bandwidth(1750000);
 	transmitter_model.enable();
 	

--- a/firmware/application/transmitter_model.hpp
+++ b/firmware/application/transmitter_model.hpp
@@ -66,7 +66,7 @@ public:
 
 private:
 	bool enabled_ { false };
-	bool rf_amp_ { true };
+	bool rf_amp_ { false };
 	int32_t lna_gain_db_ { 0 };
 	uint32_t channel_bandwidth_ { 1 };
 	uint32_t baseband_bandwidth_ { max2837::filter::bandwidth_minimum };

--- a/firmware/application/ui/ui_transmitter.hpp
+++ b/firmware/application/ui/ui_transmitter.hpp
@@ -37,6 +37,10 @@
 #include <algorithm>
 #include <functional>
 
+#define POWER_THRESHOLD_HIGH	47
+#define POWER_THRESHOLD_MED		38
+#define POWER_THRESHOLD_LOW		17
+
 namespace ui {
 
 class TXGainField : public NumberField {
@@ -83,7 +87,22 @@ private:
 		.background = Color::black(),
 		.foreground = Color::dark_grey(),
 	};
-	
+	const Style style_power_low {
+		.font = font::fixed_8x16,
+		.background = Color::black(),
+		.foreground = Color::yellow(),
+	};
+	const Style style_power_med {
+		.font = font::fixed_8x16,
+		.background = Color::black(),
+		.foreground = Color::orange(),
+	};
+	const Style style_power_high {
+		.font = font::fixed_8x16,
+		.background = Color::black(),
+		.foreground = Color::red(),
+	};
+
 	bool lock_ { false };
 	bool transmitting_ { false };
 	
@@ -95,10 +114,15 @@ private:
 		{ 0, 3 * 8, 5 * 8, 1 * 16 },
 		"Gain:"
 	};
-	TXGainField field_gain {
-		{ 5 * 8, 3 * 8 }
-	};
 	
+	NumberField field_gain {
+		{ 5 * 8, 3 * 8 },
+		2,
+		{ max2837::tx::gain_db_range.minimum, max2837::tx::gain_db_range.maximum },
+		max2837::tx::gain_db_step,
+		' '
+	};
+
 	Text text_bw {
 		{ 11 * 8, 1 * 8, 9 * 8, 1 * 16 },
 		"BW:   kHz"
@@ -111,6 +135,19 @@ private:
 		' '
 	};
 	
+	Text text_amp {
+		{ 11 * 8, 3 * 8, 5 * 8, 1 * 16 },
+		"Amp:"
+	};
+
+	NumberField field_amp {
+		{ 16 * 8, 3 * 8 },
+		2,
+		{ 0, 14 },
+		14,
+		' '
+	};
+
 	Button button_start {
 		{ 21 * 8, 1 * 8, 9 * 8, 32 },
 		"START"
@@ -118,6 +155,10 @@ private:
 
 	void on_tuning_frequency_changed(rf::Frequency f);
 	void on_channel_bandwidth_changed(uint32_t channel_bandwidth);
+	void on_tx_gain_changed(int32_t tx_gain);
+	void on_tx_amp_changed(bool rf_amp);
+
+	void update_gainlevel_styles(void);
 };
 
 } /* namespace ui */


### PR DESCRIPTION
A tiny PR adding rf_amp field to ui_transmitter in order to have a better control of output power. Useful when using a power amplifier. Added a color grading indicator of the total tx gain + some fix.

![SCR_0003](https://user-images.githubusercontent.com/13287666/79507246-b2d3c100-8037-11ea-92a4-b9a9d77d53d1.PNG)

![SCR_0004](https://user-images.githubusercontent.com/13287666/79507615-545b1280-8038-11ea-982c-395eadf72cc8.PNG)

* ui_transmitter : Added rf_amp field
* ui_transmitter : Added color grading depending on gain settings
* Removed TransmitterModel::set_rf_amp(bool) call from every apps loading ui_transmit
* transmitter_model : RF_amp disabled by default
* APRS Tx app : Fixed frequency keypad not showing up
* Morse Tx app : Removed TransmitterModel::set_lna() and TransmitterModel::set_vga() calls