### PR TITLE
Dockerfile-no-git + ccache symlinks for gcc-arm-none-eabi

### DIFF
--- a/dockerfile-nogit
+++ b/dockerfile-nogit
@@ -1,0 +1,31 @@
+FROM ubuntu:xenial
+
+# Set location to download ARM toolkit from.
+# This will need to be changed over time or replaced with a static link to the latest release.
+ENV ARMBINURL=https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2?revision=108bd959-44bd-4619-9c19-26187abf5225&la=en&hash=E788CE92E5DFD64B2A8C246BBA91A249CB8E2D2D \
+	PATH=$HOME/bin:$PATH:/opt/build/armbin/bin
+
+#Create volume /havoc/bin for compiled firmware binaries
+VOLUME /havoc
+WORKDIR /havoc/firmware
+
+# Fetch dependencies from APT
+RUN apt-get update && \
+	apt-get install -y git tar wget dfu-util cmake python3 python-pip ccache && \
+	apt-get -qy autoremove
+
+RUN pip install pyyaml
+
+# Grab the GNU ARM toolchain from arm.com
+# Then extract contents to /opt/build/armbin/
+RUN mkdir /opt/build && cd /opt/build && \
+	wget -O gcc-arm-none-eabi $ARMBINURL && \
+	mkdir armbin && \
+	tar --strip=1 -xjvf gcc-arm-none-eabi -C armbin
+
+# Configure CCACHE
+RUN mkdir ~/bin && cd ~/bin && \
+	for tool in gcc g++ cpp c++;do ln -s $(which ccache) arm-none-eabi-$tool;done
+
+CMD cd .. && cd build && \
+    cmake .. && make firmware


### PR DESCRIPTION
This is a dockerfile that uses the local source instead of pulling a fresh copy from git, and additionally installs ccache for a fast compilation (with few changes the compile time could be less than a minute instead of the normal very long process):
![e5b55f78-dc9f-4e8f-8d21-6b2d470c2eaf](https://user-images.githubusercontent.com/1091420/80269653-eeaefc00-86b1-11ea-884e-588fac5c55b8.gif)

For building:
`docker build -t portapackccache -f dockerfile-nogit .`

For running (in the root of the repo):
`docker run -it -v ${PWD}:/havoc portapackccache`

For subsequential runs I use _Kinematic_ to call this same instance, as seen in the upper gif. If you run it again, it might create a new container, hence losing the benefits of `ccache`.

It is also in Docker Hub.