### PR TITLE
Fix for: I’ve found a repeatable M4 Guru error.

### DIFF
--- a/firmware/application/apps/analog_audio_app.cpp
+++ b/firmware/application/apps/analog_audio_app.cpp
@@ -162,6 +162,7 @@ AnalogAudioView::~AnalogAudioView() {
 	// both?
 	audio::output::stop();
 
+	receiver_model.set_sampling_rate(3072000); 	// Just a hack to avoid hanging other apps if the last modulation was SPEC
 	receiver_model.disable();
 
 	baseband::shutdown();


### PR DESCRIPTION
This fixes M4 Guru Meditation errors while fiddling switching from the Audio app left in SPEC
> I’ve found a repeatable M4 Guru error. 
> Turn unit on
> Select Receivers
> select pocsag wait 5 seconds then exit
> Select audio. change to spec mode. wait 5 seconds then exit
> select radiosonde
> M4 Guru Meditation Unhandled hard lock up.
> 
> _Originally posted by @fcanaan in https://github.com/furrtek/portapack-havoc/issues/350#issuecomment-625015627_